### PR TITLE
Config/#29 vercel 경고에 따른 의존성 버전 업데이트

### DIFF
--- a/apps/web/app/api/admin/[partyId]/approvals/route.ts
+++ b/apps/web/app/api/admin/[partyId]/approvals/route.ts
@@ -9,6 +9,36 @@ import {
 } from "@pkg/shared";
 import type { ClimbingLevel } from "@pkg/shared";
 
+// 타입 정의
+interface LevelScore {
+  user_id: string;
+  score: number;
+}
+
+interface User {
+  id: string;
+  nickname: string;
+  email: string | null;
+}
+
+interface PartyMember {
+  user_id: string;
+  team_id: string | null;
+}
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface PersonalRanking {
+  userId: string;
+  nickname: string;
+  teamId: string | null;
+  teamName: string | null;
+  totalScore: number;
+}
+
 /**
  * 랭킹 계산 및 rankings 테이블 업데이트
  * @deprecated 이 함수는 더 이상 사용하지 않음 (워커가 처리)
@@ -24,19 +54,21 @@ async function _updateRankings(supabase: SupabaseClient, partyId: string) {
         .eq("approved", true);
     });
 
-    let personalRankings: any[] = [];
+    let personalRankings: PersonalRanking[] = [];
 
     if (personalScoresResult.success && personalScoresResult.data) {
-      const userIds = [...new Set(personalScoresResult.data.map((item: any) => item.user_id))];
+      const userIds = [
+        ...new Set(personalScoresResult.data.map((item: LevelScore) => item.user_id)),
+      ];
 
       if (userIds.length > 0) {
         const usersResult = await executeSupabaseQuery(async () => {
           return await supabase.from("users").select("id, nickname, email").in("id", userIds);
         });
 
-        const usersMap = new Map();
+        const usersMap = new Map<string, User>();
         if (usersResult.success && usersResult.data) {
-          usersResult.data.forEach((user: any) => {
+          usersResult.data.forEach((user: User) => {
             usersMap.set(user.id, user);
           });
         }
@@ -50,10 +82,10 @@ async function _updateRankings(supabase: SupabaseClient, partyId: string) {
             .in("user_id", userIds);
         });
 
-        const teamMap = new Map();
+        const teamMap = new Map<string, Team>();
         if (membersResult.success && membersResult.data) {
           const teamIds = membersResult.data
-            .map((m: any) => m.team_id)
+            .map((m: PartyMember) => m.team_id)
             .filter((id: string | null) => id !== null);
 
           if (teamIds.length > 0) {
@@ -62,13 +94,13 @@ async function _updateRankings(supabase: SupabaseClient, partyId: string) {
             });
 
             if (teamsResult.success && teamsResult.data) {
-              teamsResult.data.forEach((team: any) => {
+              teamsResult.data.forEach((team: Team) => {
                 teamMap.set(team.id, team);
               });
             }
           }
 
-          membersResult.data.forEach((member: any) => {
+          membersResult.data.forEach((member: PartyMember) => {
             if (member.team_id) {
               const team = teamMap.get(member.team_id);
               if (team) {
@@ -79,7 +111,7 @@ async function _updateRankings(supabase: SupabaseClient, partyId: string) {
         }
 
         const personalScores: Record<string, number> = {};
-        personalScoresResult.data.forEach((item: any) => {
+        personalScoresResult.data.forEach((item: LevelScore) => {
           const userId = item.user_id;
           personalScores[userId] = (personalScores[userId] || 0) + (item.score || 0);
         });
@@ -142,7 +174,10 @@ async function _updateRankings(supabase: SupabaseClient, partyId: string) {
  * 승인 대기 목록 조회 API (관리자용)
  * GET /api/admin/[partyId]/approvals
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -240,14 +275,17 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
 
     const gameRequests =
       gameRequestsResult.success && gameRequestsResult.data
-        ? gameRequestsResult.data.map((gs: any) => ({
-            id: gs.id,
-            team_id: gs.team_id,
-            team_name: gs.teams?.name || "알 수 없음",
-            status: gs.status,
-            // pending 상태일 때는 started_at이 null이므로, id를 기반으로 시간을 추정하거나 null 허용
-            requested_at: gs.started_at || gs.leader_confirmed_at || new Date().toISOString(), // null 방지
-          }))
+        ? gameRequestsResult.data.map((gs) => {
+            const team = Array.isArray(gs.teams) ? gs.teams[0] : gs.teams;
+            return {
+              id: gs.id,
+              team_id: gs.team_id,
+              team_name: team?.name || "알 수 없음",
+              status: gs.status,
+              // pending 상태일 때는 started_at이 null이므로, id를 기반으로 시간을 추정하거나 null 허용
+              requested_at: gs.started_at || gs.leader_confirmed_at || new Date().toISOString(), // null 방지
+            };
+          })
         : [];
 
     console.log("✅ 반환할 게임 요청:", gameRequests);
@@ -267,7 +305,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
  * 점수 승인 API (관리자용)
  * POST /api/admin/[partyId]/approvals
  */
-export async function POST(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/admin/[partyId]/challenges/records/[recordId]/invalidate/route.ts
+++ b/apps/web/app/api/admin/[partyId]/challenges/records/[recordId]/invalidate/route.ts
@@ -9,7 +9,7 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ partyId: string; recordId: string }> },
-) {
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/admin/[partyId]/challenges/records/route.ts
+++ b/apps/web/app/api/admin/[partyId]/challenges/records/route.ts
@@ -6,7 +6,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 챌린지 기록 저장 API (관리자용)
  * POST /api/admin/[partyId]/challenges/records
  */
-export async function POST(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -115,7 +118,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ par
  * 챌린지 기록 조회 API (관리자용)
  * GET /api/admin/[partyId]/challenges/records
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/admin/[partyId]/challenges/route.ts
+++ b/apps/web/app/api/admin/[partyId]/challenges/route.ts
@@ -6,7 +6,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 챌린지 기록 조회 API (관리자용)
  * GET /api/admin/[partyId]/challenges
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -44,7 +47,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
  * 챌린지 기록 저장 API (관리자용)
  * POST /api/admin/[partyId]/challenges
  */
-export async function POST(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/admin/[partyId]/rankings/calculate/route.ts
+++ b/apps/web/app/api/admin/[partyId]/rankings/calculate/route.ts
@@ -8,6 +8,46 @@ import {
 } from "@pkg/shared";
 import { getLevelGroup, type ClimbingLevel, type LevelGroup } from "@pkg/shared";
 
+// 타입 정의
+interface PartyMember {
+  user_id: string;
+  level: string | null;
+  team_id: string | null;
+}
+
+interface TotalScore {
+  user_id: string;
+  total_score: number | null;
+}
+
+interface User {
+  id: string;
+  nickname: string;
+  email: string | null;
+}
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface UserRanking {
+  userId: string;
+  nickname: string;
+  teamId: string | null;
+  teamName: string | null;
+  totalScore: number;
+}
+
+interface RankingResult {
+  userId: string;
+  nickname: string;
+  teamId: string | null;
+  teamName: string | null;
+  totalScore: number;
+  rank: number;
+}
+
 /**
  * 랭킹 계산 (워커용)
  * 큐에서 작업을 가져와서 랭킹을 계산하고 rankings 테이블 업데이트
@@ -16,7 +56,7 @@ import { getLevelGroup, type ClimbingLevel, type LevelGroup } from "@pkg/shared"
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ partyId?: string }> },
-) {
+): Promise<Response> {
   const supabase = createAdminClient();
 
   try {
@@ -96,11 +136,11 @@ async function calculateGroupRankings(supabase: SupabaseClient, partyId: string)
       .eq("party_id", partyId);
   });
 
-  const userIds = membersResult.data.map((m: any) => m.user_id);
+  const userIds = (membersResult.data as PartyMember[]).map((m) => m.user_id);
   const totalScoresMap = new Map<string, number>();
 
   if (totalScoresResult.success && totalScoresResult.data) {
-    totalScoresResult.data.forEach((item: any) => {
+    (totalScoresResult.data as TotalScore[]).forEach((item) => {
       totalScoresMap.set(item.user_id, item.total_score || 0);
     });
   }
@@ -116,17 +156,17 @@ async function calculateGroupRankings(supabase: SupabaseClient, partyId: string)
     return await supabase.from("users").select("id, nickname, email").in("id", userIds);
   });
 
-  const usersMap = new Map();
+  const usersMap = new Map<string, User>();
   if (usersResult.success && usersResult.data) {
-    usersResult.data.forEach((user: any) => {
+    (usersResult.data as User[]).forEach((user) => {
       usersMap.set(user.id, user);
     });
   }
 
   // 4. 팀 정보 조회
-  const teamIds = membersResult.data
-    .map((m: any) => m.team_id)
-    .filter((id: string | null) => id !== null);
+  const teamIds = (membersResult.data as PartyMember[])
+    .map((m) => m.team_id)
+    .filter((id): id is string => id !== null);
 
   const teamsMap = new Map();
   if (teamIds.length > 0) {
@@ -135,7 +175,7 @@ async function calculateGroupRankings(supabase: SupabaseClient, partyId: string)
     });
 
     if (teamsResult.success && teamsResult.data) {
-      teamsResult.data.forEach((team: any) => {
+      (teamsResult.data as Team[]).forEach((team) => {
         teamsMap.set(team.id, team);
       });
     }
@@ -158,7 +198,7 @@ async function calculateGroupRankings(supabase: SupabaseClient, partyId: string)
     totalScore: number;
   }> = [];
 
-  membersResult.data.forEach((member: any) => {
+  (membersResult.data as PartyMember[]).forEach((member) => {
     const userId = member.user_id;
     const userBaseLevel = member.level as ClimbingLevel | null;
     const totalScore = totalScoresMap.get(userId) || 0;
@@ -221,7 +261,7 @@ async function updateGroupRankings(
   supabase: SupabaseClient,
   partyId: string,
   group: LevelGroup,
-  rankings: any[],
+  rankings: RankingResult[],
 ) {
   const result = await executeSupabaseQuery(async () => {
     return await supabase
@@ -304,7 +344,16 @@ async function calculateTeamRankings(supabase: SupabaseClient, partyId: string) 
 /**
  * 팀 랭킹 저장
  */
-async function updateTeamRankings(supabase: SupabaseClient, partyId: string, rankings: any[]) {
+async function updateTeamRankings(
+  supabase: SupabaseClient,
+  partyId: string,
+  rankings: Array<{
+    teamId: string;
+    teamName: string;
+    totalScore: number;
+    rank: number;
+  }>,
+) {
   const result = await executeSupabaseQuery(async () => {
     return await supabase
       .from("rankings")

--- a/apps/web/app/api/admin/[partyId]/rankings/route.ts
+++ b/apps/web/app/api/admin/[partyId]/rankings/route.ts
@@ -2,6 +2,36 @@ import { getServerSession, authOptions } from "@pkg/auth";
 import { createAdminClient } from "@pkg/supabase/server";
 import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supabase/api-helpers";
 
+// 타입 정의
+interface RankingItem {
+  userId: string;
+  nickname: string;
+  teamId: string | null;
+  teamName: string | null;
+  totalScore: number;
+  rank: number;
+}
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface ChallengeRecord {
+  team_id: string;
+  attempt_number: number;
+  duration: string | null;
+  status: string;
+  started_at: string | null;
+}
+
+interface TeamChallengeData {
+  bestTime: string | null;
+  bestStartedAt: string | null;
+  attempts: number;
+  failures: number;
+}
+
 /**
  * "5분 23초" 형식의 문자열을 밀리초로 변환
  */
@@ -18,7 +48,10 @@ function parseDurationToMs(duration: string | null): number {
  * 전체 랭킹 조회 API (관리자용)
  * GET /api/admin/[partyId]/rankings
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -34,11 +67,29 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
     const supabase = createAdminClient();
 
     // Supabase SQL 함수로 그룹별 랭킹 계산 (점수 높은 순으로 정렬)
-    let cruxRankings: any[] = [];
-    let gripRankings: any[] = [];
-    let personalRankings: any[] = [];
-    let teamRankings: any[] = [];
-    let challengeRankings: any[] = [];
+    let cruxRankings: RankingItem[] = [];
+    let gripRankings: RankingItem[] = [];
+    let personalRankings: Array<{
+      user: { id: string; nickname: string };
+      totalScore: number;
+      rank: number;
+    }> = [];
+    let teamRankings: Array<{
+      teamId: string;
+      teamName: string;
+      totalScore: number;
+      rank: number;
+    }> = [];
+    let challengeRankings: Array<{
+      teamId: string;
+      teamName: string;
+      bestTime: string | null;
+      attempts: number;
+      failures: number;
+      status: string;
+      rank?: number;
+      time?: string;
+    }> = [];
 
     // Crux 그룹 랭킹 조회 (SQL 함수 사용)
     const cruxResult = await executeSupabaseQuery(async () => {
@@ -48,14 +99,23 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
     });
 
     if (cruxResult.success && cruxResult.data) {
-      cruxRankings = cruxResult.data.map((item: any) => ({
-        userId: item.user_id,
-        nickname: item.nickname,
-        teamId: item.team_id,
-        teamName: item.team_name,
-        totalScore: item.total_score || 0,
-        rank: item.rank,
-      }));
+      cruxRankings = cruxResult.data.map(
+        (item: {
+          user_id: string;
+          nickname: string;
+          team_id: string | null;
+          team_name: string | null;
+          total_score: number | null;
+          rank: number;
+        }) => ({
+          userId: item.user_id,
+          nickname: item.nickname,
+          teamId: item.team_id,
+          teamName: item.team_name,
+          totalScore: item.total_score || 0,
+          rank: item.rank,
+        }),
+      );
     }
 
     // Grip 그룹 랭킹 조회 (SQL 함수 사용)
@@ -66,14 +126,23 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
     });
 
     if (gripResult.success && gripResult.data) {
-      gripRankings = gripResult.data.map((item: any) => ({
-        userId: item.user_id,
-        nickname: item.nickname,
-        teamId: item.team_id,
-        teamName: item.team_name,
-        totalScore: item.total_score || 0,
-        rank: item.rank,
-      }));
+      gripRankings = gripResult.data.map(
+        (item: {
+          user_id: string;
+          nickname: string;
+          team_id: string | null;
+          team_name: string | null;
+          total_score: number | null;
+          rank: number;
+        }) => ({
+          userId: item.user_id,
+          nickname: item.nickname,
+          teamId: item.team_id,
+          teamName: item.team_name,
+          totalScore: item.total_score || 0,
+          rank: item.rank,
+        }),
+      );
     }
 
     // 개인 랭킹 (Crux + Grip 합쳐서 정렬) - SQL 함수 결과를 합치기만 함
@@ -131,7 +200,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
         }));
 
       // 챌린지 랭킹 계산
-      const allTeamIds = teamsResult.data.map((team: any) => team.id);
+      const allTeamIds = teamsResult.data.map((team: Team) => team.id);
 
       // 챌린지 기록 조회
       const challengeRecordsResult = await executeSupabaseQuery(async () => {
@@ -144,9 +213,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
       });
 
       // 팀별로 최고 기록 찾기
-      const teamChallengeMap = new Map<string, any>();
+      const teamChallengeMap = new Map<string, TeamChallengeData>();
       if (challengeRecordsResult.success && challengeRecordsResult.data) {
-        challengeRecordsResult.data.forEach((record: any) => {
+        challengeRecordsResult.data.forEach((record: ChallengeRecord) => {
           const teamId = record.team_id;
           if (!teamChallengeMap.has(teamId)) {
             teamChallengeMap.set(teamId, {
@@ -158,6 +227,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
           }
 
           const teamData = teamChallengeMap.get(teamId);
+          if (!teamData) {
+            // 이미 위에서 set했으므로 이 경우는 발생하지 않아야 하지만 타입 안전성을 위해 체크
+            return;
+          }
           // 실패 기록도 attempts에 포함
           teamData.attempts += 1;
           if (record.status === "failed") {
@@ -175,7 +248,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
       }
 
       // 모든 팀에 대해 챌린지 랭킹 생성
-      challengeRankings = teamsResult.data.map((team: any) => {
+      challengeRankings = teamsResult.data.map((team: Team) => {
         const teamData = teamChallengeMap.get(team.id);
         const attempts = teamData?.attempts || 0;
         const failures = teamData?.failures || 0;

--- a/apps/web/app/api/admin/[partyId]/teams/route.ts
+++ b/apps/web/app/api/admin/[partyId]/teams/route.ts
@@ -6,7 +6,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 파티의 팀 목록 조회 API (관리자용)
  * GET /api/admin/[partyId]/teams
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -95,7 +98,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
  * 팀 생성 API (관리자용)
  * POST /api/admin/[partyId]/teams
  */
-export async function POST(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -202,7 +208,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ par
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ partyId: string }> },
-) {
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -265,7 +271,7 @@ export async function PATCH(
 export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ partyId: string }> },
-) {
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/admin/[partyId]/users/route.ts
+++ b/apps/web/app/api/admin/[partyId]/users/route.ts
@@ -6,7 +6,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 파티 멤버 목록 조회 API (관리자용)
  * GET /api/admin/[partyId]/users
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -141,7 +144,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ partyId: string }> },
-) {
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/auth/delete-account/route.ts
+++ b/apps/web/app/api/auth/delete-account/route.ts
@@ -5,43 +5,30 @@ import { getServerSession, authOptions, userService } from "@pkg/auth";
  * 회원 탈퇴 API
  * DELETE /api/auth/delete-account
  */
-export async function DELETE() {
+export async function DELETE(): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
 
     if (!session || !session.user) {
-      return NextResponse.json(
-        { error: "인증되지 않은 사용자입니다" },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: "인증되지 않은 사용자입니다" }, { status: 401 });
     }
 
-    const userId = (session.user as any).id;
+    const userId = (session.user as { id?: string })?.id;
 
     if (!userId) {
-      return NextResponse.json(
-        { error: "사용자 ID를 찾을 수 없습니다" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "사용자 ID를 찾을 수 없습니다" }, { status: 400 });
     }
 
     // Supabase에서 사용자 삭제
     const success = await userService.deleteUser(userId);
 
     if (!success) {
-      return NextResponse.json(
-        { error: "회원 탈퇴에 실패했습니다" },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: "회원 탈퇴에 실패했습니다" }, { status: 500 });
     }
 
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("회원 탈퇴 에러:", error);
-    return NextResponse.json(
-      { error: "서버 오류가 발생했습니다" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
   }
 }
-

--- a/apps/web/app/api/cron/update-party-status/route.ts
+++ b/apps/web/app/api/cron/update-party-status/route.ts
@@ -12,7 +12,7 @@ import { executeSupabaseQuery } from "@pkg/supabase/api-helpers";
  *
  * 보안: 환경변수로 cron secret을 확인하여 인증
  */
-export async function GET(request: Request) {
+export async function GET(request: Request): Promise<Response> {
   try {
     // Cron secret 인증 (환경변수에서 확인)
     const authHeader = request.headers.get("authorization");

--- a/apps/web/app/api/party/[partyId]/game-session/route.ts
+++ b/apps/web/app/api/party/[partyId]/game-session/route.ts
@@ -31,7 +31,10 @@ interface BoardSnapshot {
  * 게임 세션 조회 API
  * GET /api/party/[partyId]/game-session?teamId=xxx
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -181,7 +184,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
  * 게임 세션 생성/업데이트 API
  * POST /api/party/[partyId]/game-session
  */
-export async function POST(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/party/[partyId]/member/route.ts
+++ b/apps/web/app/api/party/[partyId]/member/route.ts
@@ -7,7 +7,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 파티 멤버 정보 조회 API
  * GET /api/party/[partyId]/member
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/party/[partyId]/permissions/route.ts
+++ b/apps/web/app/api/party/[partyId]/permissions/route.ts
@@ -7,7 +7,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 특정 파티에서 사용자의 권한 확인 API
  * GET /api/party/[partyId]/permissions
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     // 1. 인증 확인
     const session = await getServerSession(authOptions);

--- a/apps/web/app/api/party/[partyId]/rankings/route.ts
+++ b/apps/web/app/api/party/[partyId]/rankings/route.ts
@@ -1,6 +1,47 @@
 import { getServerSession, authOptions } from "@pkg/auth";
-import { createServerClient, createAdminClient } from "@pkg/supabase/server";
+import { createAdminClient } from "@pkg/supabase/server";
 import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supabase/api-helpers";
+
+// 타입 정의
+interface RankingItem {
+  userId: string;
+  nickname: string;
+  teamId: string | null;
+  teamName: string | null;
+  totalScore: number;
+  rank: number;
+}
+
+interface TeamRankingItem {
+  rank: number;
+  teamNumber: number;
+  teamId: string;
+  teamName: string;
+  totalScore: number;
+  usedPieces: number;
+  totalPieces: number;
+  completedLines: number;
+}
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface ChallengeRecord {
+  team_id: string;
+  attempt_number: number;
+  duration: string | null;
+  status: string;
+  started_at: string | null;
+}
+
+interface TeamChallengeData {
+  bestTime: string | null;
+  bestStartedAt: string | null;
+  attempts: number;
+  failures: number;
+}
 
 /**
  * "5분 23초" 형식의 문자열을 밀리초로 변환
@@ -14,16 +55,14 @@ function parseDurationToMs(duration: string | null): number {
   return (minutes * 60 + seconds) * 1000;
 }
 
-type TeamMember = {
-  name: string;
-  level: string;
-};
-
 /**
  * 랭킹 조회 API (일반 사용자용)
  * GET /api/party/[partyId]/rankings
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -74,10 +113,19 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
     const party = partyResult.data;
 
     // Supabase SQL 함수로 그룹별 랭킹 계산 (점수 높은 순으로 정렬)
-    let cruxRankings: any[] = [];
-    let gripRankings: any[] = [];
-    let teamRankings: any[] = [];
-    let challengeRankings: any[] = [];
+    let cruxRankings: RankingItem[] = [];
+    let gripRankings: RankingItem[] = [];
+    let teamRankings: TeamRankingItem[] = [];
+    let challengeRankings: Array<{
+      teamId: string;
+      teamName: string;
+      bestTime: string | null;
+      attempts: number;
+      failures: number;
+      status: string;
+      rank?: number;
+      time?: string;
+    }> = [];
 
     // Crux 그룹 랭킹 조회 (SQL 함수 사용)
     const cruxResult = await executeSupabaseQuery(async () => {
@@ -87,14 +135,23 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
     });
 
     if (cruxResult.success && cruxResult.data) {
-      cruxRankings = cruxResult.data.map((item: any) => ({
-        userId: item.user_id,
-        nickname: item.nickname,
-        teamId: item.team_id,
-        teamName: item.team_name,
-        totalScore: item.total_score || 0,
-        rank: item.rank,
-      }));
+      cruxRankings = cruxResult.data.map(
+        (item: {
+          user_id: string;
+          nickname: string;
+          team_id: string | null;
+          team_name: string | null;
+          total_score: number | null;
+          rank: number;
+        }) => ({
+          userId: item.user_id,
+          nickname: item.nickname,
+          teamId: item.team_id,
+          teamName: item.team_name,
+          totalScore: item.total_score || 0,
+          rank: item.rank,
+        }),
+      );
     }
 
     // Grip 그룹 랭킹 조회 (SQL 함수 사용)
@@ -105,14 +162,23 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
     });
 
     if (gripResult.success && gripResult.data) {
-      gripRankings = gripResult.data.map((item: any) => ({
-        userId: item.user_id,
-        nickname: item.nickname,
-        teamId: item.team_id,
-        teamName: item.team_name,
-        totalScore: item.total_score || 0,
-        rank: item.rank,
-      }));
+      gripRankings = gripResult.data.map(
+        (item: {
+          user_id: string;
+          nickname: string;
+          team_id: string | null;
+          team_name: string | null;
+          total_score: number | null;
+          rank: number;
+        }) => ({
+          userId: item.user_id,
+          nickname: item.nickname,
+          teamId: item.team_id,
+          teamName: item.team_name,
+          totalScore: item.total_score || 0,
+          rank: item.rank,
+        }),
+      );
     }
 
     // 개인 랭킹 (Crux + Grip 합쳐서 정렬) - SQL 함수 결과를 합치기만 함
@@ -140,32 +206,42 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
     });
 
     // 모든 팀을 포함하되, 랭킹 데이터가 있으면 사용
-    const teamRankingsMap = new Map<string, any>();
+    const teamRankingsMap = new Map<string, TeamRankingItem>();
     if (teamRankingsResult.success && teamRankingsResult.data) {
-      teamRankingsResult.data.forEach((item: any) => {
-        const teamNumberMatch = item.team_name?.match(/(\d+)/);
-        const teamNumber = teamNumberMatch ? parseInt(teamNumberMatch[1], 10) : 0;
+      teamRankingsResult.data.forEach(
+        (item: {
+          team_id: string;
+          team_name: string;
+          total_score: number | null;
+          used_pieces: number | null;
+          total_pieces: number | null;
+          completed_lines: number | null;
+          rank: number;
+        }) => {
+          const teamNumberMatch = item.team_name?.match(/(\d+)/);
+          const teamNumber = teamNumberMatch?.[1] ? parseInt(teamNumberMatch[1], 10) : 0;
 
-        teamRankingsMap.set(item.team_id, {
-          rank: item.rank,
-          teamNumber,
-          teamId: item.team_id,
-          teamName: item.team_name,
-          totalScore: Number(item.total_score) || 0,
-          usedPieces: Number(item.used_pieces) || 0,
-          totalPieces: Number(item.total_pieces) || 0,
-          completedLines: Number(item.completed_lines) || 0,
-        });
-      });
+          teamRankingsMap.set(item.team_id, {
+            rank: item.rank,
+            teamNumber,
+            teamId: item.team_id,
+            teamName: item.team_name,
+            totalScore: Number(item.total_score) || 0,
+            usedPieces: Number(item.used_pieces) || 0,
+            totalPieces: Number(item.total_pieces) || 0,
+            completedLines: Number(item.completed_lines) || 0,
+          });
+        },
+      );
     }
 
     // 모든 팀을 포함 (랭킹 데이터가 없으면 0점으로 설정)
     if (allTeamsResult.success && allTeamsResult.data) {
       const existingRankingsCount = teamRankingsMap.size;
-      allTeamsResult.data.forEach((team: any, index: number) => {
+      allTeamsResult.data.forEach((team: Team, index: number) => {
         if (!teamRankingsMap.has(team.id)) {
           const teamNumberMatch = team.name?.match(/(\d+)/);
-          const teamNumber = teamNumberMatch ? parseInt(teamNumberMatch[1], 10) : index + 1;
+          const teamNumber = teamNumberMatch?.[1] ? parseInt(teamNumberMatch[1], 10) : index + 1;
 
           teamRankingsMap.set(team.id, {
             rank: existingRankingsCount + index + 1,
@@ -214,16 +290,32 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
 
       if (teamMembersResult.success && teamMembersResult.data) {
         const membersMap = new Map<string, Array<{ name: string; level: string }>>();
-        teamMembersResult.data.forEach((member: any) => {
-          if (!member.team_id) return;
-          if (!membersMap.has(member.team_id)) {
-            membersMap.set(member.team_id, []);
-          }
-          membersMap.get(member.team_id)?.push({
-            name: member.users?.nickname || "알 수 없음",
-            level: member.level || "White",
-          });
-        });
+        teamMembersResult.data.forEach(
+          (member: {
+            team_id: string | null;
+            level: string | null;
+            users?:
+              | {
+                  id: string;
+                  nickname: string;
+                }
+              | {
+                  id: string;
+                  nickname: string;
+                }[]
+              | null;
+          }) => {
+            if (!member.team_id) return;
+            if (!membersMap.has(member.team_id)) {
+              membersMap.set(member.team_id, []);
+            }
+            const user = Array.isArray(member.users) ? member.users[0] : member.users;
+            membersMap.get(member.team_id)?.push({
+              name: user?.nickname || "알 수 없음",
+              level: member.level || "White",
+            });
+          },
+        );
 
         teamRankings = teamRankings.map((team) => ({
           ...team,
@@ -234,7 +326,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
 
     // 챌린지 랭킹 계산
     if (allTeamsResult.success && allTeamsResult.data) {
-      const allTeamIds = allTeamsResult.data.map((team: any) => team.id);
+      const allTeamIds = allTeamsResult.data.map((team: Team) => team.id);
 
       // 챌린지 기록 조회
       const challengeRecordsResult = await executeSupabaseQuery(async () => {
@@ -247,9 +339,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
       });
 
       // 팀별로 최고 기록 찾기
-      const teamChallengeMap = new Map<string, any>();
+      const teamChallengeMap = new Map<string, TeamChallengeData>();
       if (challengeRecordsResult.success && challengeRecordsResult.data) {
-        challengeRecordsResult.data.forEach((record: any) => {
+        challengeRecordsResult.data.forEach((record: ChallengeRecord) => {
           const teamId = record.team_id;
           if (!teamChallengeMap.has(teamId)) {
             teamChallengeMap.set(teamId, {
@@ -261,6 +353,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
           }
 
           const teamData = teamChallengeMap.get(teamId);
+          if (!teamData) {
+            // 이미 위에서 set했으므로 이 경우는 발생하지 않아야 하지만 타입 안전성을 위해 체크
+            return;
+          }
           // 실패 기록도 attempts에 포함
           teamData.attempts += 1;
           if (record.status === "failed") {
@@ -278,7 +374,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
       }
 
       // 모든 팀에 대해 챌린지 랭킹 생성
-      challengeRankings = allTeamsResult.data.map((team: any) => {
+      challengeRankings = allTeamsResult.data.map((team: Team) => {
         const teamData = teamChallengeMap.get(team.id);
         const attempts = teamData?.attempts || 0;
         const failures = teamData?.failures || 0;

--- a/apps/web/app/api/party/[partyId]/route.ts
+++ b/apps/web/app/api/party/[partyId]/route.ts
@@ -7,7 +7,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 파티 정보 조회 API
  * GET /api/party/[partyId]
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     // 1. 인증 확인
     const session = await getServerSession(authOptions);

--- a/apps/web/app/api/party/[partyId]/ruleset/route.ts
+++ b/apps/web/app/api/party/[partyId]/ruleset/route.ts
@@ -6,7 +6,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 파티 룰셋 조회 API
  * GET /api/party/[partyId]/ruleset
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -76,7 +79,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
       return errorResponse("파티 룰셋을 찾을 수 없습니다", 404);
     }
 
-    const ruleset = rulesetResult.data as { level_points?: any };
+    const ruleset = rulesetResult.data as {
+      level_points?: Record<string, number> | null;
+    };
 
     return successResponse({
       level_points: ruleset.level_points || null,

--- a/apps/web/app/api/party/[partyId]/scores/route.ts
+++ b/apps/web/app/api/party/[partyId]/scores/route.ts
@@ -8,7 +8,10 @@ import { ENABLED_LEVELS, calculateLevelScore, type LevelPointsConfig } from "@pk
  * 점수 조회 API
  * GET /api/party/[partyId]/scores
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -92,7 +95,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
  * 점수 저장/업데이트 API
  * POST /api/party/[partyId]/scores
  */
-export async function POST(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/party/[partyId]/team-blocks/route.ts
+++ b/apps/web/app/api/party/[partyId]/team-blocks/route.ts
@@ -8,7 +8,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 팀 블럭 조회 API
  * GET /api/party/[partyId]/team-blocks?teamId=xxx
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
@@ -133,7 +136,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ part
  * 팀 블럭 추가 API (특수 블럭 획득 등)
  * POST /api/party/[partyId]/team-blocks
  */
-export async function POST(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/party/[partyId]/team-score/route.ts
+++ b/apps/web/app/api/party/[partyId]/team-score/route.ts
@@ -6,7 +6,10 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * 팀 점수 조회 API (테트리스 게임 점수 합산)
  * GET /api/party/[partyId]/team-score?teamId=xxx
  */
-export async function GET(request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/app/api/party/create/route.ts
+++ b/apps/web/app/api/party/create/route.ts
@@ -14,7 +14,7 @@ const pendingRequests = new Map<string, Promise<any>>();
  * - 모든 파티는 기본 크루 "클IE밍"에 속함
  * - 중복 요청 방지: 동일한 사용자의 동시 요청은 하나만 처리
  */
-export async function POST(request: Request) {
+export async function POST(request: Request): Promise<Response> {
   let userId: string | null = null;
   let requestKey: string | null = null;
 

--- a/apps/web/app/api/party/join/route.ts
+++ b/apps/web/app/api/party/join/route.ts
@@ -8,7 +8,7 @@ import { numberToLevel, type ClimbingLevel } from "@pkg/shared";
  * 파티 참가 API
  * POST /api/party/join
  */
-export async function POST(request: Request) {
+export async function POST(request: Request): Promise<Response> {
   // 함수가 실행되는지 확인하기 위한 로그
   console.log("[API] /api/party/join POST 요청 수신");
   try {

--- a/apps/web/app/api/party/update-status/route.ts
+++ b/apps/web/app/api/party/update-status/route.ts
@@ -11,7 +11,7 @@ import type { PartyStatus } from "@pkg/shared";
  * 요구사항:
  * - 관리자 권한 필요 (role = 'admin')
  */
-export async function PATCH(request: Request) {
+export async function PATCH(request: Request): Promise<Response> {
   try {
     // 1. 인증 확인
     const session = await getServerSession(authOptions);

--- a/apps/web/app/api/supabase/test/route.ts
+++ b/apps/web/app/api/supabase/test/route.ts
@@ -7,7 +7,7 @@ import { executeSupabaseQuery, successResponse, errorResponse } from "@pkg/supab
  * GET /api/supabase/test?admin=true (강제 관리자 모드)
  * 로그인한 사용자의 role이 'admin'이면 자동으로 관리자 모드 사용
  */
-export async function GET(request: Request) {
+export async function GET(request: Request): Promise<Response> {
   try {
     const { searchParams } = new URL(request.url);
     const forceAdmin = searchParams.get("admin") === "true";
@@ -96,7 +96,7 @@ export async function GET(request: Request) {
  * body: { table, action, data?, useAdmin?: boolean }
  * 로그인한 사용자의 role이 'admin'이면 자동으로 관리자 모드 사용
  */
-export async function POST(request: Request) {
+export async function POST(request: Request): Promise<Response> {
   try {
     const body = await request.json();
     const { table, action, data: requestData, useAdmin: forceAdmin = false } = body;

--- a/apps/web/app/api/user/parties/route.ts
+++ b/apps/web/app/api/user/parties/route.ts
@@ -1,13 +1,33 @@
-import { NextResponse } from "next/server";
 import { getServerSession, authOptions } from "@pkg/auth";
 import { createServerClient, createAdminClient } from "@pkg/supabase/server";
 import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supabase/api-helpers";
+
+// 타입 정의
+interface PartyMember {
+  party_id: string;
+  team_id: string | null;
+}
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface Party {
+  id: string;
+  [key: string]: unknown;
+}
+
+interface UserMemberInfo {
+  team_id: string | null;
+  team_name: string | null;
+}
 
 /**
  * 사용자가 참여한 파티 목록 조회 API
  * GET /api/user/parties
  */
-export async function GET() {
+export async function GET(): Promise<Response> {
   try {
     // 1. 인증 확인
     const session = await getServerSession(authOptions);
@@ -93,9 +113,11 @@ export async function GET() {
 
     // 5. 각 파티별 참가자 수 조회 및 사용자 팀 정보 추가
     // team_id가 있으면 teams 테이블에서 team 정보 조회 (Service Role Key 사용)
-    const teamIds = members.map((m: any) => m.team_id).filter((id: any) => id != null);
+    const teamIds = (members as PartyMember[])
+      .map((m) => m.team_id)
+      .filter((id): id is string => id != null);
 
-    const teamMap = new Map();
+    const teamMap = new Map<string, Team>();
     if (teamIds.length > 0) {
       const { data: teams, error: teamsError } = await supabaseForQuery
         .from("teams")
@@ -103,14 +125,14 @@ export async function GET() {
         .in("id", teamIds);
 
       if (!teamsError && teams) {
-        teams.forEach((team: any) => {
+        teams.forEach((team: Team) => {
           teamMap.set(team.id, team);
         });
       }
     }
 
-    const memberMap = new Map();
-    members.forEach((member: any) => {
+    const memberMap = new Map<string, UserMemberInfo>();
+    (members as PartyMember[]).forEach((member) => {
       const team = member.team_id ? teamMap.get(member.team_id) : null;
       memberMap.set(member.party_id, {
         team_id: member.team_id,
@@ -119,7 +141,7 @@ export async function GET() {
     });
 
     const partiesWithCount = await Promise.all(
-      partiesResult.data.map(async (party: any) => {
+      partiesResult.data.map(async (party: Party) => {
         try {
           const { count, error: countError } = await supabaseForQuery
             .from("party_members")

--- a/apps/web/app/api/user/permissions/route.ts
+++ b/apps/web/app/api/user/permissions/route.ts
@@ -13,7 +13,7 @@ import { successResponse, errorResponse, executeSupabaseQuery } from "@pkg/supab
  * - canCreateParty: 파티 생성 가능 여부
  * - canManagePermissions: 권한 관리 가능 여부
  */
-export async function GET(request: Request) {
+export async function GET(request: Request): Promise<Response> {
   try {
     // 1. 인증 확인
     const session = await getServerSession(authOptions);

--- a/apps/web/app/api/user/profile/route.ts
+++ b/apps/web/app/api/user/profile/route.ts
@@ -8,7 +8,7 @@ import { numberToLevel, levelToNumber, type ClimbingLevel } from "@pkg/shared";
  * 사용자 프로필 조회 API
  * GET /api/user/profile
  */
-export async function GET() {
+export async function GET(): Promise<Response> {
   // 함수가 실행되는지 확인하기 위한 로그
   console.log("[API] /api/user/profile GET 요청 수신");
   try {
@@ -138,7 +138,7 @@ export async function GET() {
  * 사용자 프로필 수정 API
  * PATCH /api/user/profile
  */
-export async function PATCH(request: Request) {
+export async function PATCH(request: Request): Promise<Response> {
   try {
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,21 +1,25 @@
-import type { NextConfig } from 'next';
+import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   transpilePackages: [
-    '@pkg/auth',
-    '@pkg/config',
-    '@pkg/domain',
-    '@pkg/env',
-    '@pkg/features',
-    '@pkg/shared',
-    '@pkg/style',
-    '@pkg/supabase',
-    '@pkg/ui',
-    '@pkg/ui-web',
+    "@pkg/auth",
+    "@pkg/config",
+    "@pkg/domain",
+    "@pkg/env",
+    "@pkg/features",
+    "@pkg/shared",
+    "@pkg/style",
+    "@pkg/supabase",
+    "@pkg/ui",
+    "@pkg/ui-web",
   ],
   experimental: {
-    optimizePackageImports: ['react', 'react-dom'],
+    optimizePackageImports: ["react", "react-dom"],
+  },
+  turbopack: {
+    root: path.resolve(__dirname, "../.."),
   },
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,11 +21,11 @@
     "@pkg/ui": "workspace:*",
     "@pkg/ui-web": "workspace:*",
     "lucide-react": "^0.475.0",
-    "next": "16.0.0",
+    "next": "16.0.7",
     "next-auth": "^4.24.13",
     "next-themes": "^0.4.4",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
+    "react": "19.2.1",
+    "react-dom": "19.2.1",
     "tw-animate-css": "^1.3.6"
   },
   "devDependencies": {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -2,7 +2,7 @@ import { withAuth } from "next-auth/middleware";
 import { NextResponse } from "next/server";
 
 export default withAuth(
-  function middleware(req) {
+  function middleware(_req) {
     return NextResponse.next();
   },
   {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -13,12 +13,9 @@ export default withAuth(
       signIn: "/login",
     },
     secret: process.env.NEXTAUTH_SECRET,
-  }
+  },
 );
 
 export const config = {
-  matcher: [
-    "/dashboard/:path*",
-    "/party/:path*",
-  ],
+  matcher: ["/dashboard/:path*", "/party/:path*"],
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,10 +7,6 @@
       }
     ]
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "next-env.d.ts",
-    ".next/types/**/*.ts"
-  ]
+  "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "**/node_modules/**", ".next", "dist", "build"]
 }

--- a/packages/auth/lib/logger.ts
+++ b/packages/auth/lib/logger.ts
@@ -6,35 +6,34 @@
 const isDev = process.env.NODE_ENV === "development";
 
 export const authLogger = {
-  jwt: (data: any) => {
+  jwt: (data: unknown) => {
     if (isDev) console.log("🔐 [NextAuth JWT]", data);
   },
   session: (message: string) => {
     if (isDev) console.log("📱 [NextAuth Session]", message);
   },
-  signIn: (data: any) => {
+  signIn: (data: unknown) => {
     if (isDev) console.log("🔑 [NextAuth SignIn]", data);
   },
   provider: (message: string) => {
     if (isDev) console.log("🔌 [Provider]", message);
   },
-  config: (data: any) => {
+  config: (data: unknown) => {
     if (isDev) console.log("⚙️ [Config]", data);
   },
-  error: (message: string, error?: any) => {
+  error: (message: string, error?: unknown) => {
     console.error("❌ [Auth Error]", message, error || "");
   },
 };
 
 export const supabaseLogger = {
-  sync: (message: string, data?: any) => {
+  sync: (message: string, data?: unknown) => {
     if (isDev) console.log("🔄 [Supabase Sync]", message, data || "");
   },
   success: (message: string) => {
     if (isDev) console.log("✅ [Supabase]", message);
   },
-  error: (message: string, error?: any) => {
+  error: (message: string, error?: unknown) => {
     console.error("❌ [Supabase Error]", message, error || "");
   },
 };
-

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -8,9 +8,11 @@
     "./options": "./lib/options.ts",
     "./constants": "./lib/constants.ts"
   },
+  "dependencies": {
+    "next-auth": "^4"
+  },
   "peerDependencies": {
     "next": "^16",
-    "next-auth": "^4",
     "react": "^19"
   }
 }

--- a/packages/shared/src/services/ranking-queue-service.ts
+++ b/packages/shared/src/services/ranking-queue-service.ts
@@ -8,8 +8,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 // executeSupabaseQuery는 api-helpers에서 가져오지만,
 // shared 패키지에서는 직접 구현하거나 다른 방법 사용
 async function executeQuery<T>(
-  queryFn: () => Promise<{ data: T | null; error: any }>,
-): Promise<{ success: boolean; data?: T; error?: any }> {
+  queryFn: () => Promise<{ data: T | null; error: unknown }>,
+): Promise<{ success: boolean; data?: T; error?: unknown }> {
   try {
     const result = await queryFn();
     if (result.error) {
@@ -45,7 +45,14 @@ export async function enqueueRankingCalculation(
     if (!result.success) {
       return {
         success: false,
-        error: result.error?.message || "큐에 추가하는데 실패했습니다",
+        error:
+          (result.error instanceof Error
+            ? result.error.message
+            : typeof result.error === "object" &&
+                result.error !== null &&
+                "message" in result.error
+              ? String(result.error.message)
+              : null) || "큐에 추가하는데 실패했습니다",
       };
     }
 
@@ -153,7 +160,14 @@ export async function completeRankingCalculation(
     if (!result.success) {
       return {
         success: false,
-        error: result.error?.message || "완료 처리 실패",
+        error:
+          (result.error instanceof Error
+            ? result.error.message
+            : typeof result.error === "object" &&
+                result.error !== null &&
+                "message" in result.error
+              ? String(result.error.message)
+              : null) || "완료 처리 실패",
       };
     }
 
@@ -193,7 +207,14 @@ export async function failRankingCalculation(
     if (!result.success) {
       return {
         success: false,
-        error: result.error?.message || "실패 처리 실패",
+        error:
+          (result.error instanceof Error
+            ? result.error.message
+            : typeof result.error === "object" &&
+                result.error !== null &&
+                "message" in result.error
+              ? String(result.error.message)
+              : null) || "실패 처리 실패",
       };
     }
 

--- a/packages/supabase/src/api-helpers.ts
+++ b/packages/supabase/src/api-helpers.ts
@@ -50,7 +50,7 @@ export function errorResponse(
  */
 export function handleSupabaseResult<T>(
   result: SupabaseResult<T>,
-  successMessage?: string,
+  _successMessage?: string,
 ) {
   if (result.success && result.data !== null) {
     return successResponse(result.data);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 14.1.0(semantic-release@25.0.2(typescript@5.9.3))
       '@storybook/react':
         specifier: ^10.0.6
-        version: 10.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)
+        version: 10.0.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.1.16
         version: 4.1.16
@@ -56,7 +56,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/node':
         specifier: ^24.9.1
         version: 24.9.1
@@ -209,22 +209,22 @@ importers:
         version: link:../../packages/ui-web
       lucide-react:
         specifier: ^0.475.0
-        version: 0.475.0(react@19.2.0)
+        version: 0.475.0(react@19.2.1)
       next:
-        specifier: 16.0.0
-        version: 16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 16.0.7
+        version: 16.0.7(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.24.13(next@16.0.7(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-themes:
         specifier: ^0.4.4
-        version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
-        specifier: 19.2.0
-        version: 19.2.0
+        specifier: 19.2.1
+        version: 19.2.1
       react-dom:
-        specifier: 19.2.0
-        version: 19.2.0(react@19.2.0)
+        specifier: 19.2.1
+        version: 19.2.1(react@19.2.1)
       tw-animate-css:
         specifier: ^1.3.6
         version: 1.4.0
@@ -246,10 +246,10 @@ importers:
     dependencies:
       next:
         specifier: ^16
-        version: 16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.0))(react@19.2.0)
       next-auth:
         specifier: ^4
-        version: 4.24.13(next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.24.13(next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.0))(react@19.2.0))(react-dom@19.2.1(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19
         version: 19.2.0
@@ -280,7 +280,7 @@ importers:
         version: 2.78.0
       next:
         specifier: ^16
-        version: 16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   packages/ui:
     dependencies:
@@ -1418,8 +1418,17 @@ packages:
   '@next/env@16.0.0':
     resolution: {integrity: sha512-s5j2iFGp38QsG1LWRQaE2iUY3h1jc014/melHFfLdrsMJPqxqDQwWNwyQTcNoUSGZlCVZuM7t7JDMmSyRilsnA==}
 
+  '@next/env@16.0.7':
+    resolution: {integrity: sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw==}
+
   '@next/swc-darwin-arm64@16.0.0':
     resolution: {integrity: sha512-/CntqDCnk5w2qIwMiF0a9r6+9qunZzFmU0cBX4T82LOflE72zzH6gnOjCwUXYKOBlQi8OpP/rMj8cBIr18x4TA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.0.7':
+    resolution: {integrity: sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1430,8 +1439,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@16.0.7':
+    resolution: {integrity: sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-linux-arm64-gnu@16.0.0':
     resolution: {integrity: sha512-E2IHMdE+C1k+nUgndM13/BY/iJY9KGCphCftMh7SXWcaQqExq/pJU/1Hgn8n/tFwSoLoYC/yUghOv97tAsIxqg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-gnu@16.0.7':
+    resolution: {integrity: sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1442,8 +1463,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-arm64-musl@16.0.7':
+    resolution: {integrity: sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-x64-gnu@16.0.0':
     resolution: {integrity: sha512-sdyOg4cbiCw7YUr0F/7ya42oiVBXLD21EYkSwN+PhE4csJH4MSXUsYyslliiiBwkM+KsuQH/y9wuxVz6s7Nstg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@16.0.7':
+    resolution: {integrity: sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1454,14 +1487,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-musl@16.0.7':
+    resolution: {integrity: sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-win32-arm64-msvc@16.0.0':
     resolution: {integrity: sha512-bmo3ncIJKUS9PWK1JD9pEVv0yuvp1KPuOsyJTHXTv8KDrEmgV/K+U0C75rl9rhIaODcS7JEb6/7eJhdwXI0XmA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@16.0.7':
+    resolution: {integrity: sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@16.0.0':
     resolution: {integrity: sha512-O1cJbT+lZp+cTjYyZGiDwsOjO3UHHzSqobkPNipdlnnuPb1swfcuY6r3p8dsKU4hAIEO4cO67ZCfVVH/M1ETXA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.0.7':
+    resolution: {integrity: sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4792,6 +4843,28 @@ packages:
   next@16.0.0:
     resolution: {integrity: sha512-nYohiNdxGu4OmBzggxy9rczmjIGI+TpR5vbKTsE1HqYwNm1B+YSiugSrFguX6omMOKnDHAmBPY4+8TNJk0Idyg==}
     engines: {node: '>=20.9.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@16.0.7:
+    resolution: {integrity: sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==}
+    engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -5403,6 +5476,11 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
+  react-dom@19.2.1:
+    resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
+    peerDependencies:
+      react: ^19.2.1
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5449,6 +5527,10 @@ packages:
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.1:
+    resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
 
   read-package-up@11.0.0:
@@ -7870,28 +7952,54 @@ snapshots:
 
   '@next/env@16.0.0': {}
 
+  '@next/env@16.0.7': {}
+
   '@next/swc-darwin-arm64@16.0.0':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.0.7':
     optional: true
 
   '@next/swc-darwin-x64@16.0.0':
     optional: true
 
+  '@next/swc-darwin-x64@16.0.7':
+    optional: true
+
   '@next/swc-linux-arm64-gnu@16.0.0':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.0.7':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.0.0':
     optional: true
 
+  '@next/swc-linux-arm64-musl@16.0.7':
+    optional: true
+
   '@next/swc-linux-x64-gnu@16.0.0':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.0.7':
     optional: true
 
   '@next/swc-linux-x64-musl@16.0.0':
     optional: true
 
+  '@next/swc-linux-x64-musl@16.0.7':
+    optional: true
+
   '@next/swc-win32-arm64-msvc@16.0.0':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.0.7':
+    optional: true
+
   '@next/swc-win32-x64-msvc@16.0.0':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.0.7':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -8357,6 +8465,11 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
+  '@storybook/icons@1.6.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
   '@storybook/nextjs@10.0.6(next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1)':
     dependencies:
       '@babel/core': 7.28.5
@@ -8460,11 +8573,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
 
-  '@storybook/react-dom-shim@10.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))':
+  '@storybook/react-dom-shim@10.0.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))':
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      storybook: 10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
 
   '@storybook/react@10.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)':
     dependencies:
@@ -8476,13 +8589,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@storybook/react@10.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)':
+  '@storybook/react@10.0.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@storybook/react-dom-shim': 10.0.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      storybook: 10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
     optionalDependencies:
       typescript: 5.9.3
 
@@ -8701,12 +8814,12 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
@@ -11506,6 +11619,10 @@ snapshots:
     dependencies:
       react: 19.2.0
 
+  lucide-react@0.475.0(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -11639,25 +11756,45 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-auth@4.24.13(next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next-auth@4.24.13(next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.0))(react@19.2.0))(react-dom@19.2.1(react@19.2.0))(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.0))(react@19.2.0)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.24.3
       preact-render-to-string: 5.2.3(preact@10.24.3)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.1(react@19.2.0)
+      uuid: 8.3.2
+
+  next-auth@4.24.13(next@16.0.7(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@panva/hkdf': 1.2.1
+      cookie: 0.7.2
+      jose: 4.15.9
+      next: 16.0.7(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      oauth: 0.9.15
+      openid-client: 5.7.1
+      preact: 10.24.3
+      preact-render-to-string: 5.2.3(preact@10.24.3)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
       uuid: 8.3.2
 
   next-themes@0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+
+  next-themes@0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -11677,6 +11814,78 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.0.0
       '@next/swc-win32-arm64-msvc': 16.0.0
       '@next/swc-win32-x64-msvc': 16.0.0
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.34.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@next/env': 16.0.0
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001751
+      postcss: 8.4.31
+      react: 19.2.0
+      react-dom: 19.2.1(react@19.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.0.0
+      '@next/swc-darwin-x64': 16.0.0
+      '@next/swc-linux-arm64-gnu': 16.0.0
+      '@next/swc-linux-arm64-musl': 16.0.0
+      '@next/swc-linux-x64-gnu': 16.0.0
+      '@next/swc-linux-x64-musl': 16.0.0
+      '@next/swc-win32-arm64-msvc': 16.0.0
+      '@next/swc-win32-x64-msvc': 16.0.0
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.34.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.0.0(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@next/env': 16.0.0
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001751
+      postcss: 8.4.31
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.0.0
+      '@next/swc-darwin-x64': 16.0.0
+      '@next/swc-linux-arm64-gnu': 16.0.0
+      '@next/swc-linux-arm64-musl': 16.0.0
+      '@next/swc-linux-x64-gnu': 16.0.0
+      '@next/swc-linux-x64-musl': 16.0.0
+      '@next/swc-win32-arm64-msvc': 16.0.0
+      '@next/swc-win32-x64-msvc': 16.0.0
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.34.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.0.7(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@next/env': 16.0.7
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001751
+      postcss: 8.4.31
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.0.7
+      '@next/swc-darwin-x64': 16.0.7
+      '@next/swc-linux-arm64-gnu': 16.0.7
+      '@next/swc-linux-arm64-musl': 16.0.7
+      '@next/swc-linux-x64-gnu': 16.0.7
+      '@next/swc-linux-x64-musl': 16.0.7
+      '@next/swc-win32-arm64-msvc': 16.0.7
+      '@next/swc-win32-x64-msvc': 16.0.7
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.4
     transitivePeerDependencies:
@@ -12272,6 +12481,16 @@ snapshots:
       react: 19.2.0
       scheduler: 0.27.0
 
+  react-dom@19.2.1(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
+  react-dom@19.2.1(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      scheduler: 0.27.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -12308,6 +12527,8 @@ snapshots:
       '@types/react': 19.2.2
 
   react@19.2.0: {}
+
+  react@19.2.1: {}
 
   read-package-up@11.0.0:
     dependencies:
@@ -12850,10 +13071,10 @@ snapshots:
       - utf-8-validate
       - vite
 
-  storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
+  storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.2.2(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 1.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@storybook/icons': 1.6.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
@@ -13006,6 +13227,13 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.0
+    optionalDependencies:
+      '@babel/core': 7.28.5
+
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.1
     optionalDependencies:
       '@babel/core': 7.28.5
 


### PR DESCRIPTION
관련 이슈: Closes #29 

## 변경 목적

Next.js 16.0.7로 업그레이드 후 발생한 빌드 에러와 타입 경고를 해결하고, 코드의 타입 안정성을 향상시키기 위해 설정을 변경했습니다.

## 변경 내용

### 빌드/배포 설정
- **Next.js middleware → proxy 마이그레이션**: `middleware.ts`를 `proxy.ts`로 변경하여 Next.js 16의 deprecated 경고 해결
- **Turbopack 워크스페이스 루트 설정**: `next.config.ts`에 `turbopack.root` 설정 추가하여 여러 lockfile 경고 해결

### 의존성 (Dependencies)
- **packages/auth/package.json**: `next-auth`를 `peerDependencies`에서 `dependencies`로 이동
  - 업데이트 이유: Turbopack 빌드 시 모듈 해석 문제 해결

### 타입 안정성 개선
- **Route Handler 반환 타입 명시**: 모든 API route handler 함수에 `Promise<Response>` 반환 타입 추가
- **any 타입 제거**: ESLint 경고를 해결하기 위해 `any` 타입을 적절한 인터페이스로 변경
- **TypeScript 설정**: `tsconfig.json`에 `exclude` 설정 추가

### 변경 전

```typescript
// middleware.ts (deprecated)
export default withAuth(
  function middleware(req) {
    return NextResponse.next();
  },
  { ... }
);

// Route handler (타입 추론 실패)
export async function GET(request: Request, { params }) {
  return successResponse(data);
}

// packages/auth/package.json
{
  "peerDependencies": {
    "next-auth": "^4"
  }
}
```

### 변경 후

```typescript
// proxy.ts (Next.js 16 권장)
export default withAuth(
  function middleware(_req) {
    return NextResponse.next();
  },
  { ... }
);

// Route handler (명시적 타입)
export async function GET(
  request: Request,
  { params }: { params: Promise<{ partyId: string }> },
): Promise<Response> {
  return successResponse(data);
}

// packages/auth/package.json
{
  "dependencies": {
    "next-auth": "^4"
  },
  "peerDependencies": {
    "next": "^16",
    "react": "^19"
  }
}

// next.config.ts
{
  "turbopack": {
    "root": path.resolve(__dirname, "../..")
  }
}
```

## 테스트

변경 사항을 어떻게 확인했나요?

- [x] 개발 환경에서 테스트 완료
- [x] 빌드 성공 확인 (`pnpm build:web` 성공)

### 테스트 결과
- ✅ Next.js 빌드 성공
- ✅ TypeScript 타입 체크 통과
- ✅ ESLint 경고 해결 (any 타입 관련)
- ✅ 모든 route handler 타입 에러 해결

## 체크리스트

- [x] Breaking Changes 확인 (의존성 업데이트인 경우) - Breaking Change 없음
- [x] 의존성 충돌 확인 (의존성 업데이트인 경우) - 충돌 없음

## 추가 정보

### 주요 변경 파일 목록

**설정 파일:**
- `apps/web/middleware.ts` → `apps/web/proxy.ts` (파일명 변경)
- `apps/web/next.config.ts` (turbopack.root 추가)
- `apps/web/tsconfig.json` (exclude 추가)
- `packages/auth/package.json` (next-auth dependencies로 이동)

**타입 개선:**
- 모든 `apps/web/app/api/**/route.ts` 파일 (반환 타입 추가)
- `apps/web/app/api/admin/[partyId]/approvals/route.ts` (any 타입 제거)
- `apps/web/app/api/party/[partyId]/rankings/route.ts` (any 타입 제거)
- `apps/web/app/api/admin/[partyId]/rankings/route.ts` (any 타입 제거)
- 기타 여러 route 파일들

**코드 품질:**
- `packages/auth/lib/logger.ts` (any → unknown)
- `packages/shared/src/services/ranking-queue-service.ts` (any → unknown)
- `packages/supabase/src/api-helpers.ts` (사용되지 않는 매개변수 수정)

### 참고사항
- `next-auth` 내부 타입 에러는 node_modules 내부 문제로 빌드에는 영향 없음 (`skipLibCheck: true` 설정됨)
- IDE에서 TypeScript 서버 재시작 시 경고가 사라질 수 있음

